### PR TITLE
Add dark theme toggle

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,16 @@
+import React, { useState } from 'react';
 import WeatherCard from './components/WeatherCard';
 import Navbar from './components/Navbar';
 
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import CssBaseline from '@material-ui/core/CssBaseline';
 
 import background from './assets/background3.jpg';
 
 const useStyles = makeStyles((theme) => ({
   App: {
-    backgroundImage: `url(${background})`,
-    backgroundPosition: 'center', 
-    backgroundSize: 'cover', 
+    backgroundPosition: 'center',
+    backgroundSize: 'cover',
     backgroundRepeat: 'no-repeat',
     height: '100vh',
     padding: "20px"
@@ -23,16 +24,28 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function App() {
+  const [darkMode, setDarkMode] = useState(false);
+  const theme = createMuiTheme({
+    palette: {
+      type: darkMode ? 'dark' : 'light',
+    },
+  });
+
   const classes = useStyles();
+  const backgroundStyle = darkMode
+    ? { backgroundColor: theme.palette.background.default }
+    : { backgroundImage: `url(${background})` };
+
   return (
-    <>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
       <div className={classes.root}>
-        <Navbar />
+        <Navbar darkMode={darkMode} setDarkMode={setDarkMode} />
       </div>
-      <div className={classes.App}>
+      <div className={classes.App} style={backgroundStyle}>
         <WeatherCard />
       </div>
-    </>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -4,6 +4,8 @@ import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
+import Switch from '@material-ui/core/Switch';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 import { makeStyles } from '@material-ui/core/styles';
 
@@ -16,7 +18,7 @@ const useStyles = makeStyles((theme) => ({
 
 
 
-const Navbar = () => {
+const Navbar = ({ darkMode, setDarkMode }) => {
     const classes = useStyles();
 
     return (
@@ -26,7 +28,11 @@ const Navbar = () => {
                 <Typography variant="h6" className={classes.title}>
                     United Weather
                 </Typography>
-                <Button 
+                <FormControlLabel
+                    control={<Switch checked={darkMode} onChange={() => setDarkMode(!darkMode)} color="default" />}
+                    label="Dark Mode"
+                />
+                <Button
                     color="inherit"
                     onClick={()=> window.open("https://openweathermap.org/api", "_blank")}
                 >OpenWeatherMap API</Button>

--- a/src/components/WeatherCard.js
+++ b/src/components/WeatherCard.js
@@ -29,7 +29,7 @@ const useStyles = makeStyles((theme) => ({
     padding: "20px"
   },
   card: {
-    backgroundColor: "white",
+    backgroundColor: theme.palette.background.paper,
     textAlign: "center"
   },
   weatherInfo: {

--- a/src/components/WeatherInfo.js
+++ b/src/components/WeatherInfo.js
@@ -22,7 +22,7 @@ atmospheric: {
 card: {
     minWidth: "50vw",
     minHeight: "80wh",
-    backgroundColor: "white",
+    backgroundColor: theme.palette.background.paper,
     textAlign: "center",
 },
 cardTop: {


### PR DESCRIPTION
## Summary
- add a dark theme switch in the Navbar
- manage MUI theme in `App.js`
- use theme palette for card backgrounds

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb0472b048326aca3dc500ff76bae